### PR TITLE
fix: correct EOF delimiter in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
           {
             echo 'changelog<<EOF'
             cat CHANGELOG.md
-            echo EOF
+            echo 'EOF'
           } >> $GITHUB_OUTPUT
 
       - name: Commit version changes


### PR DESCRIPTION
Fix multiline output format in GitHub Actions workflow by properly quoting the EOF delimiter to ensure it's treated as a literal string.